### PR TITLE
feat(Pagination): ellipsis should separate at least 2 pages

### DIFF
--- a/packages/radix-vue/src/Pagination/utils.ts
+++ b/packages/radix-vue/src/Pagination/utils.ts
@@ -24,8 +24,8 @@ export function getRange(currentPage: number, pageCount: number, siblingCount: n
   const leftSiblingIndex = Math.max(currentPage - siblingCount, firstPageIndex)
   const rightSiblingIndex = Math.min(currentPage + siblingCount, lastPageIndex)
 
-  const showLeftEllipsis = leftSiblingIndex > firstPageIndex + 1
-  const showRightEllipsis = rightSiblingIndex < lastPageIndex - 1
+  const showLeftEllipsis = leftSiblingIndex > firstPageIndex + 2
+  const showRightEllipsis = rightSiblingIndex < lastPageIndex - 2
 
   if (showEdges) {
     /**


### PR DESCRIPTION
Hello! 

Rendering an ellipsis in the Pagination component when it only put instead of a single page item is not that useful I think:

![](https://github.com/andreww2012/radix-vue/assets/6554045/ff9f6e09-bc9a-4b77-a567-977388b6cd35)

This PR changes this behavior by requiring the difference between pages that ellipsis separate be at least 2.